### PR TITLE
Add exception handling to socket calls

### DIFF
--- a/BlocklyPropClient.py
+++ b/BlocklyPropClient.py
@@ -10,7 +10,6 @@ import webbrowser
 import os
 import ip
 import sys
-import time
 import BlocklyServer
 
 __author__ = 'Michel & Vale'

--- a/ip.py
+++ b/ip.py
@@ -1,7 +1,7 @@
-__author__ = 'Michel'
-
 import os
 import socket
+
+__author__ = 'Michel'
 
 if os.name != "nt":
     import fcntl
@@ -12,8 +12,15 @@ if os.name != "nt":
         return socket.inet_ntoa(fcntl.ioctl(s.fileno(), 0x8915, struct.pack('256s',
                                 if_name[:15]))[20:24])
 
+
 def get_lan_ip():
-    ip = socket.gethostbyname(socket.gethostname())
+    # Find the client's IP address
+    try:
+        ip = socket.gethostbyname(socket.gethostname())
+    except socket.error as msg:
+        print msg.message
+        ip = "0.0.0.0"
+
     if ip.startswith("127.") and os.name != "nt":
         interfaces = [
             "eth0",
@@ -26,6 +33,7 @@ def get_lan_ip():
             "ath1",
             "ppp0",
             ]
+
         for if_name in interfaces:
             try:
                 ip = get_interface_ip(if_name)


### PR DESCRIPTION
The calls used to determine the client's IP address fail if the client hostname cannot be resolved. Under this condition, the client appears to launch and then immediately fail without any indication as to why it failed.

The update traps the exception and prints an error message to the console. 