### PR TITLE
Update to add MacOS logging and FTDI driver detection

### DIFF
--- a/BlocklyHardware.py
+++ b/BlocklyHardware.py
@@ -1,0 +1,94 @@
+import os
+import logging
+from sys import platform
+from subprocess import Popen, PIPE, check_output, CalledProcessError
+
+# Define platform constants
+PLATFORM_MACOS = 'darwin'
+PLATFORM_UBUNTU = 'linux2'
+
+# Define error constants
+FTDI_DRIVER_NOT_INSTALLED = 201
+FTDI_DRIVER_NOT_LOADED = 202
+PLATFORM_UNKNOWN = 2
+
+# Enable logging
+__module_logger = logging.getLogger('blockly')
+
+
+def init():
+    result = is_module_installed()
+    if result != 0:
+        return result
+
+    result = is_module_loaded()
+    if result != 0:
+        return result
+
+
+def is_module_installed():
+    if platform == PLATFORM_MACOS:
+        return __is_module_installed_macos()
+    elif platform == PLATFORM_UBUNTU:
+        return __is_module_installed_ubuntu()
+    else:
+        return PLATFORM_UNKNOWN
+
+
+def is_module_loaded():
+    if platform == PLATFORM_MACOS:
+        return __is_module_loaded_macos()
+    elif platform == PLATFORM_UBUNTU:
+        return __is_module_loaded_ubuntu()
+    else:
+        return PLATFORM_UNKNOWN
+
+
+# Ubuntu implementation
+def __is_module_installed_ubuntu():
+    try:
+        process = Popen(['cat', '/proc/modules'], stdout=PIPE, stderr=PIPE)
+        output = check_output(('grep', 'ftdi'), stdin=process.stdout)
+        __module_logger.debug('FTDI module load state')
+        __module_logger.debug(output)
+        return 0
+    except CalledProcessError:
+        __module_logger.warning('No FTDI modules detected.')
+        return FTDI_DRIVER_NOT_INSTALLED
+
+
+def __is_module_loaded_ubuntu():
+    try:
+        process = Popen(['dmesg', '-H', '-x'], stdout=PIPE, stderr=PIPE)
+        output = check_output(('grep', 'ftdi'), stdin=process.stdout)
+        process.wait()
+        __module_logger.debug(output)
+        return 0
+    except CalledProcessError:
+        __module_logger.warning('Serial port is not assigned.')
+        return FTDI_DRIVER_NOT_LOADED
+
+
+# MacOS implementation
+def __is_module_installed_macos():
+    try:
+        # Does the log directory exist
+        os.stat('/Library/Extensions/FTDIUSBSerialDriver.kext')
+        __module_logger.info('FTDI driver is installed')
+        return 0
+
+    except OSError:
+        __module_logger.error('Cannot find FTDI installation')
+        return FTDI_DRIVER_NOT_INSTALLED
+
+
+def __is_module_loaded_macos():
+    try:
+        process = Popen(['kextstat'], stdout=PIPE, stderr=PIPE)
+        output = check_output(('grep', 'FTDI'), stdin=process.stdout)
+        __module_logger.debug('FTDI module load state')
+        __module_logger.debug(output)
+        return 0
+    except CalledProcessError:
+        __module_logger.warning('No FTDI modules detected.')
+        return 1

--- a/BlocklyLogger.py
+++ b/BlocklyLogger.py
@@ -1,119 +1,85 @@
+""""
+BlocklyPropLogger manages the application logging process.
+
+
+"""
+
 import os
 import logging
 from sys import platform
-from subprocess import Popen, PIPE, check_output, CalledProcessError
 
-# Define error constants
+__author__ = 'Jim Ewald'
 
-# Logging path
-try:  # Python 2.7+
-    from logging import NullHandler
-except ImportError:
-    class NullHandler(logging.Handler):
-        def emit(self, record):
-            pass
+# Constants
+PLATFORM_MACOS = 'darwin'
 
-logging.getLogger(__name__).addHandler(NullHandler())
+path = None
 
-# Create a logger
-logger = logging.getLogger('blockly')
-logger.setLevel(logging.DEBUG)
+def init(filename = 'BlocklyPropClient.log'):
+    global path
 
-# create a file handler to log events to the debug level. Log file
-# is overwritten each time the app runs.
-handler = logging.FileHandler('BlocklyPropClient.log', mode='w')
-#handler = logging.FileHandler('BlocklyPropClient.log')
-handler.setLevel(logging.DEBUG)
+    # Set a default log file name
+    logfile_name = filename
 
-# create a console handler for error-level events
-console = logging.StreamHandler()
-console.setLevel(logging.ERROR)
+    # Set correct log file location
+    if platform == PLATFORM_MACOS:
+        logfile_name = __set_macos_logpath(filename)
+        if logfile_name is None:
+            return 1
 
-# create a logging format
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-handler.setFormatter(formatter)
-console.setFormatter(formatter)
+    path = logfile_name
 
-# add the handlers to the logger
-logger.addHandler(handler)
-logger.addHandler(console)
+    # Logging path
+    try:  # Python 2.7+
+        from logging import NullHandler
+    except ImportError:
+        class NullHandler(logging.Handler):
+            def emit(self, record):
+                pass
 
+    logging.getLogger(__name__).addHandler(NullHandler())
 
-def init():
+    # Create a logger
+    logger = logging.getLogger('blockly')
+    logger.setLevel(logging.DEBUG)
+
+    # create a file handler to log events to the debug level. Log file
+    # is overwritten each time the app runs.
+    __log_file_location = logfile_name
+    handler = logging.FileHandler(logfile_name, mode='w')
+    handler.setLevel(logging.DEBUG)
+
+    # create a console handler for error-level events
+    console = logging.StreamHandler()
+    console.setLevel(logging.ERROR)
+
+    # create a logging format
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    handler.setFormatter(formatter)
+    console.setFormatter(formatter)
+
+    # add the handlers to the logger
+    logger.addHandler(handler)
+    logger.addHandler(console)
+
     logger.info("Logger has been started.")
 
-    # Debian linux
-    if platform == 'linux2':
-        if is_module_loaded() != 0:
-            return
 
-        if check_system_messages() != 0:
-            return
-
-     # MacOS
-    if platform == 'darwin':
-        if is_macos_ftdi_module_installed() != 0:
-            return 101
-
-        if is_macos_ftdi_module_loaded != 0:
-            return 102
-
-
-def is_module_loaded():
-    try:
-        process = Popen(['cat', '/proc/modules'], stdout=PIPE, stderr=PIPE)
-        output = check_output(('grep', 'ftdi'), stdin=process.stdout)
-        logger.debug('FTDI module load state')
-        logger.debug(output)
-        return 0
-    except CalledProcessError:
-        logger.warning('No FTDI modules detected.')
-        return 1
-
-
-def check_system_messages():
-    try:
-        process = Popen(['dmesg', '-H', '-x'], stdout=PIPE, stderr=PIPE)
-        output = check_output(('grep', 'ftdi'), stdin=process.stdout)
-        process.wait()
-        logger.debug(output)
-        return 0
-    except CalledProcessError:
-        logger.warning('Serial port is not assigned.')
-        return 1
-
-
-def check_macos_logpath():
+def __set_macos_logpath(filename):
     user_home = os.path.expanduser('~')
-    log_path = user_home + '/Library/Logs/BlocklyProp'
+    log_path = user_home + '/Library/Logs/Parallax'
 
     # Does the log directory exist
     try:
         os.stat(log_path)
-        return 0
+        return log_path + '/' + filename
 
     except OSError:
         # Create a new log path
         try:
-            os.mkdirs(log_path)
+            os.makedirs(log_path)
 
         except OSError:
-            return 1
+            return None
 
-    return 0
-
-
-def is_macos_ftdi_module_loaded():
-    try:
-        process = Popen(['kextstat'], stdout=PIPE, stderr=PIPE)
-        output = check_output(('grep', 'FTDI'), stdin=process.stdout)
-        logger.debug('FTDI module load state')
-        logger.debug(output)
-        return 0
-    except CalledProcessError:
-        logger.warning('No FTDI modules detected.')
-        return 1
-
-
-def is_macos_ftdi_module_installed():
-    return 0
+    return log_path + '/' + filename

--- a/BlocklyLogger.py
+++ b/BlocklyLogger.py
@@ -1,7 +1,9 @@
+import os
 import logging
 from sys import platform
 from subprocess import Popen, PIPE, check_output, CalledProcessError
 
+# Define error constants
 
 # Logging path
 try:  # Python 2.7+
@@ -39,12 +41,22 @@ logger.addHandler(console)
 
 def init():
     logger.info("Logger has been started.")
+
+    # Debian linux
     if platform == 'linux2':
         if is_module_loaded() != 0:
             return
 
         if check_system_messages() != 0:
             return
+
+     # MacOS
+    if platform == 'darwin':
+        if is_macos_ftdi_module_installed() != 0:
+            return 101
+
+        if is_macos_ftdi_module_loaded != 0:
+            return 102
 
 
 def is_module_loaded():
@@ -69,3 +81,39 @@ def check_system_messages():
     except CalledProcessError:
         logger.warning('Serial port is not assigned.')
         return 1
+
+
+def check_macos_logpath():
+    user_home = os.path.expanduser('~')
+    log_path = user_home + '/Library/Logs/BlocklyProp'
+
+    # Does the log directory exist
+    try:
+        os.stat(log_path)
+        return 0
+
+    except OSError:
+        # Create a new log path
+        try:
+            os.mkdirs(log_path)
+
+        except OSError:
+            return 1
+
+    return 0
+
+
+def is_macos_ftdi_module_loaded():
+    try:
+        process = Popen(['kextstat'], stdout=PIPE, stderr=PIPE)
+        output = check_output(('grep', 'FTDI'), stdin=process.stdout)
+        logger.debug('FTDI module load state')
+        logger.debug(output)
+        return 0
+    except CalledProcessError:
+        logger.warning('No FTDI modules detected.')
+        return 1
+
+
+def is_macos_ftdi_module_installed():
+    return 0


### PR DESCRIPTION
This update addresses several issues. Issue #38  and #39, the BlocklyHardware module manages FTDI driver installation and operation detection for Linux and MacOS.

File-based logging is now enabled for MacOS clients. The default log file location is ~/Library/Logs/Parallax/

Updated the UI to display the location of the disk-based logging file.