### PR TITLE
Update log file placement for MacOS

### DIFF
--- a/BlocklyLogger.py
+++ b/BlocklyLogger.py
@@ -18,18 +18,7 @@ path = None
 def init(filename = 'BlocklyPropClient.log'):
     global path
 
-    # Set a default log file name
-    logfile_name = filename
-
-    # Set correct log file location
-    if platform == PLATFORM_MACOS:
-        logfile_name = __set_macos_logpath(filename)
-        if logfile_name is None:
-            return 1
-
-    path = logfile_name
-
-    # Logging path
+    # Set NullHandler as a default
     try:  # Python 2.7+
         from logging import NullHandler
     except ImportError:
@@ -39,15 +28,28 @@ def init(filename = 'BlocklyPropClient.log'):
 
     logging.getLogger(__name__).addHandler(NullHandler())
 
+    # Set a default log file name
+    logfile_name = filename
+    disable_filelogging = False
+
+    # Set correct log file location
+    if platform == PLATFORM_MACOS:
+        logfile_name = __set_macos_logpath(filename)
+        if logfile_name is None:
+            disable_filelogging = True
+        else:
+            # Set the module-level path
+            path = logfile_name
+
     # Create a logger
     logger = logging.getLogger('blockly')
     logger.setLevel(logging.DEBUG)
 
     # create a file handler to log events to the debug level. Log file
     # is overwritten each time the app runs.
-    __log_file_location = logfile_name
-    handler = logging.FileHandler(logfile_name, mode='w')
-    handler.setLevel(logging.DEBUG)
+    if not disable_filelogging:
+        handler = logging.FileHandler(logfile_name, mode='w')
+        handler.setLevel(logging.DEBUG)
 
     # create a console handler for error-level events
     console = logging.StreamHandler()
@@ -55,13 +57,17 @@ def init(filename = 'BlocklyPropClient.log'):
 
     # create a logging format
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-    handler.setFormatter(formatter)
+
+    if not disable_filelogging:
+        handler.setFormatter(formatter)
+
     console.setFormatter(formatter)
 
     # add the handlers to the logger
-    logger.addHandler(handler)
-    logger.addHandler(console)
+    if not disable_filelogging:
+        logger.addHandler(handler)
 
+    logger.addHandler(console)
     logger.info("Logger has been started.")
 
 
@@ -71,15 +77,32 @@ def __set_macos_logpath(filename):
 
     # Does the log directory exist
     try:
-        os.stat(log_path)
+        result = __verify_macos_logpath(log_path)
+        if result is None and __create_macos_logpath(log_path) is None:
+        # Try to create the directory
+            log_path = '/tmp'
+            result = __verify_macos_logpath(log_path)
+            if result is None:
+                return 1
+
         return log_path + '/' + filename
-
     except OSError:
-        # Create a new log path
-        try:
-            os.makedirs(log_path)
+        return 2
 
-        except OSError:
-            return None
 
-    return log_path + '/' + filename
+def __verify_macos_logpath(file_path):
+    try:
+        info = os.stat(file_path)
+        return info
+    except OSError as ex:
+        print ex.message
+        return None
+
+
+def __create_macos_logpath(file_path):
+    try:
+        os.makedirs(file_path)
+        return path
+    except OSError as ex:
+        print ex.message
+        return None

--- a/BlocklyPropClient.py
+++ b/BlocklyPropClient.py
@@ -157,13 +157,16 @@ class BlocklyPropClient(tk.Tk):
         self.port.set(PORT)
         self.logger.info('Port number is: %s', self.port.get())
 
-        self.logfile.set(BlocklyLogger.path)
-        self.logger.info('Disk log file location is: %s', BlocklyLogger.path)
+        if BlocklyLogger.path is None:
+            self.logfile.set(' ')
+            self.logger.info('Disk logging is inactive')
+        else:
+            self.logfile.set(BlocklyLogger.path)
+            self.logger.info('Disk log file location is: %s', BlocklyLogger.path)
 
         self.server_process = None
 
         self.q = multiprocessing.Queue()
- #       self.stdoutToQueue = StdoutToQueue(self.q)
 
         monitor = threading.Thread(target=self.text_catcher)
         monitor.daemon = True


### PR DESCRIPTION
This PR does the following:

Attempts to open a log file in the user's local Library/Logs/Parallax directory.
If that fails, attempt to create the log file in the /tmp folder. This should always work.
If that fails, disable the file logging system and continue using the console logging.
 