### PR TITLE
Mac build/sign/package updates plus project version script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ venv/
 VPython/
 *.app
 *.pkg
+*.bak
 
 #################
 ## Eclipse

--- a/BlocklyPropClient.macos.spec
+++ b/BlocklyPropClient.macos.spec
@@ -43,8 +43,7 @@ coll = COLLECT(exe,
 app = BUNDLE(coll,
              name='BlocklyPropClient.app',
              icon='BlocklyPropClient.icns',
-             bundle_identifier='com.ParallaxInc.BlocklyPropClient',
-             info_plist={'CFBundleShortVersionString': '0.5.3'})
+             bundle_identifier='com.ParallaxInc.BlocklyPropClient')
 
 # From Analysis
 #            pathex=['/Users/<username>/PythonProjects/BlocklyPropClient'],

--- a/about.txt
+++ b/about.txt
@@ -1,4 +1,4 @@
-CurrentVersion: v0.5.3
+Version: v0.5.3
 
 Contributors:
 - Michel Lampo
@@ -8,4 +8,4 @@ Contributors:
 
 Repository Source Code: http://github.com/parallaxinc/BlocklyPropClient
 
-Copyright 2015 - 2017 Parallax Inc
+Copyright 2015 - 2017 Parallax Inc.

--- a/package/blocklypropclient-installer.iss
+++ b/package/blocklypropclient-installer.iss
@@ -3,7 +3,7 @@
 
 #define MyAppName "BlocklyPropClient"
 #define MyAppVersion "0.5.3"
-#define MyAppPublisher "Parallax, Inc."
+#define MyAppPublisher "Parallax Inc."
 #define MyAppURL "http://blockly.parallax.com/"
 #define MyAppExeName "BlocklyPropClient.exe"
 

--- a/package/mac_app_sign_and_package.sh
+++ b/package/mac_app_sign_and_package.sh
@@ -244,6 +244,22 @@ fi
 echo
 
 #
+# Set bundle version number (in Info.plist)
+#
+if [[ -e ${DISTRIBUTION}${APP_BUNDLE} ]]
+then
+    if [[ -e ${DISTRIBUTION}${APP_BUNDLE}/Contents/Info.plist ]]
+    then
+       echo "Attempting to update bundle's Info.plist to version: \"${VERSION}\""
+       sed s_\<string\>0.0.0\<\/string\>_\<string\>${VERSION}\<\/string\>_ ${DISTRIBUTION}${APP_BUNDLE}/Contents/Info.plist > ${DISTRIBUTION}${APP_BUNDLE}/Contents/Info2.plist
+       rm ${DISTRIBUTION}${APP_BUNDLE}/Contents/Info.plist
+       mv ${DISTRIBUTION}${APP_BUNDLE}/Contents/Info2.plist ${DISTRIBUTION}${APP_BUNDLE}/Contents/Info.plist
+    fi
+fi
+
+echo
+
+#
 # Attempt to deeply codesign the app bundle
 #
 echo "Code signing the application bundle: ${DISTRIBUTION}${APP_BUNDLE} with identity: \"${APP_IDENTITY}\""

--- a/package/mac_app_sign_and_package.sh
+++ b/package/mac_app_sign_and_package.sh
@@ -250,11 +250,20 @@ if [[ -e ${DISTRIBUTION}${APP_BUNDLE} ]]
 then
     if [[ -e ${DISTRIBUTION}${APP_BUNDLE}/Contents/Info.plist ]]
     then
-       echo "Attempting to update bundle's Info.plist to version: \"${VERSION}\""
-       sed s_\<string\>0.0.0\<\/string\>_\<string\>${VERSION}\<\/string\>_ ${DISTRIBUTION}${APP_BUNDLE}/Contents/Info.plist > ${DISTRIBUTION}${APP_BUNDLE}/Contents/Info2.plist
-       rm ${DISTRIBUTION}${APP_BUNDLE}/Contents/Info.plist
-       mv ${DISTRIBUTION}${APP_BUNDLE}/Contents/Info2.plist ${DISTRIBUTION}${APP_BUNDLE}/Contents/Info.plist
+        if sed -i.bak s_\<string\>0.0.0\<\/string\>_\<string\>${VERSION}\<\/string\>_ ${DISTRIBUTION}${APP_BUNDLE}/Contents/Info.plist > ${DISTRIBUTION}${APP_BUNDLE}/Contents/Info2.plist
+        then
+            echo "Set bundle's Info.plist to version: \"${VERSION}\""
+        else
+            echo "[Error] Could not set bundle's version in Info.plist."
+            exit 1
+        fi
+    else
+        echo "[Error] Application bundle does not include an Info.plist file."
+        exit 1
     fi
+else
+    echo "[Error] Application bundle not found: ${DISTRIBUTION}${APP_BUNDLE}"
+    exit 1
 fi
 
 echo

--- a/set_version
+++ b/set_version
@@ -2,14 +2,14 @@
 #
 # This script sets version number entries in various files in the BlocklyPropClient project.
 #
-# Usage: $ ./set_version 1.2.3
+# Usage: $ ./set_version "1.2.3"
 
 #
 # Error if no version string declared
 #
 if [ $1X == X ]
 then
-    echo "ERROR: Must specify a version number.  Ex: \$ $0 1.2.3"
+    echo "ERROR: Must specify a version number.  Ex: \$ $0 \"1.2.3\""
     exit 1
 fi
 

--- a/set_version
+++ b/set_version
@@ -20,14 +20,14 @@ else
 fi
 }
 
-VERSION=0.5.6
+VERSION=0.5.3
 
 #
 # Adjust BlocklyPropClient.py file
 #
-VERSIONFILE =BlocklyPropClient.py
-VERSIONPATTERN =[vV][eE][rR][sS][iI][oO][nN][[:blank:]]*=[[:blank:]]*\"[0-9]+\.[0-9]+\.[0-9]+\"
-VERSIONSTRING ="VERSION = \"${VERSION}\""
+VERSIONFILE=BlocklyPropClient.py
+VERSIONPATTERN=[vV][eE][rR][sS][iI][oO][nN][[:blank:]]*=[[:blank:]]*\"[0-9]+\.[0-9]+\.[0-9]+\"
+VERSIONSTRING="VERSION = \"${VERSION}\""
 
 FindAndSetVersion
 
@@ -35,9 +35,9 @@ FindAndSetVersion
 #
 # Adjust about.txt file
 #
-VERSIONFILE =about.txt
-VERSIONPATTERN =[vV][eE][rR][sS][iI][oO][nN]:[[:blank:]]*v[[:blank:]]*[0-9]+\.[0-9]+\.[0-9]+
-VERSIONSTRING ="Version: v${VERSION}"
+VERSIONFILE=about.txt
+VERSIONPATTERN=[vV][eE][rR][sS][iI][oO][nN]:[[:blank:]]*v[[:blank:]]*[0-9]+\.[0-9]+\.[0-9]+
+VERSIONSTRING="Version: v${VERSION}"
 
 FindAndSetVersion
 
@@ -45,8 +45,8 @@ FindAndSetVersion
 #
 # Adjust package/blocklypropclient-installer.iss file
 #
-VERSIONFILE =package/blocklypropclient-installer.iss
-VERSIONPATTERN =[mM][yY][aA][pP][pP][vV][eE][rR][sS][iI][oO][nN][[:blank:]]+\"[0-9]+\.[0-9]+\.[0-9]+\"
-VERSIONSTRING ="MyAppVersion \"${VERSION}\""
+VERSIONFILE=package/blocklypropclient-installer.iss
+VERSIONPATTERN=[mM][yY][aA][pP][pP][vV][eE][rR][sS][iI][oO][nN][[:blank:]]+\"[0-9]+\.[0-9]+\.[0-9]+\"
+VERSIONSTRING="MyAppVersion \"${VERSION}\""
 
 FindAndSetVersion

--- a/set_version
+++ b/set_version
@@ -4,10 +4,12 @@
 #
 # Usage: $ ./set_version "1.2.3"
 
+
 #
 # Error if no version string declared
 #
-if [ $1X == X ]
+if [ -z "$1" ]
+#if [ $1X == X ]     <-- this doesn't work in Ubuntu
 then
     echo "ERROR: Must specify a version number.  Ex: \$ $0 \"1.2.3\""
     exit 1
@@ -30,7 +32,8 @@ VERSION=$1
 #       grep and sed, must use an expanded pattern for text where each letter is expressed in both upper/lower case.
 #       ex: Ver should be [vV][eE][rR]  
 #
-function FindAndSetVersion {
+FindAndSetVersion() {
+#function FindAndSetVersion {     <-- this doesn't work in Ubuntu
 if grep -q -E ${VERSIONPATTERN} ${VERSIONFILE} ; then
     if sed -i.bak -E "s/${VERSIONPATTERN}/${VERSIONSTRING}/" ${VERSIONFILE} ; then
         echo "Updated file \"${VERSIONFILE}\" to include: ${VERSIONSTRING}"
@@ -39,6 +42,7 @@ else
     echo "ERROR: Unable to find version string in file \"${VERSIONFILE}\""
 fi
 }
+
 
 #
 # Adjust BlocklyPropClient.py file

--- a/set_version
+++ b/set_version
@@ -1,4 +1,24 @@
 #!/bin/sh --
+#
+# This script sets version number entries in various files in the BlocklyPropClient project.
+#
+# Usage: $ ./set_version 1.2.3
+
+#
+# Error if no version string declared
+#
+if [ $1X == X ]
+then
+    echo "ERROR: Must specify a version number.  Ex: \$ $0 1.2.3"
+    exit 1
+fi
+
+
+#
+# Get version string
+#
+VERSION=$1
+
 
 #
 # FindAndSetVersion function
@@ -13,14 +33,12 @@
 function FindAndSetVersion {
 if grep -q -E ${VERSIONPATTERN} ${VERSIONFILE} ; then
     if sed -i.bak -E "s/${VERSIONPATTERN}/${VERSIONSTRING}/" ${VERSIONFILE} ; then
-        echo "Updated file \"${VERSIONFILE}\" to include \"${VERSIONSTRING}\""
+        echo "Updated file \"${VERSIONFILE}\" to include: ${VERSIONSTRING}"
     fi
 else
     echo "ERROR: Unable to find version string in file \"${VERSIONFILE}\""
 fi
 }
-
-VERSION=0.5.3
 
 #
 # Adjust BlocklyPropClient.py file

--- a/set_version
+++ b/set_version
@@ -1,0 +1,52 @@
+#!/bin/sh --
+
+#
+# FindAndSetVersion function
+#   Find and update version string in form "Version = #.#.#" 
+#   Search is: case-insensitive, space, tabs, or nothing around '=', and one or more # in each placeholder.
+#   Replace is: performed in-place inside of file; however, a backup (.bak) of the original file is also made.  
+#
+# NOTE: sed on Mac doesn't include a case-insensitive option.  To keep the search pattern equivalent for both
+#       grep and sed, must use an expanded pattern for text where each letter is expressed in both upper/lower case.
+#       ex: Ver should be [vV][eE][rR]  
+#
+function FindAndSetVersion {
+if grep -q -E ${VERSIONPATTERN} ${VERSIONFILE} ; then
+    if sed -i.bak -E "s/${VERSIONPATTERN}/${VERSIONSTRING}/" ${VERSIONFILE} ; then
+        echo "Updated file \"${VERSIONFILE}\" to include \"${VERSIONSTRING}\""
+    fi
+else
+    echo "ERROR: Unable to find version string in file \"${VERSIONFILE}\""
+fi
+}
+
+VERSION=0.5.6
+
+#
+# Adjust BlocklyPropClient.py file
+#
+VERSIONFILE =BlocklyPropClient.py
+VERSIONPATTERN =[vV][eE][rR][sS][iI][oO][nN][[:blank:]]*=[[:blank:]]*\"[0-9]+\.[0-9]+\.[0-9]+\"
+VERSIONSTRING ="VERSION = \"${VERSION}\""
+
+FindAndSetVersion
+
+
+#
+# Adjust about.txt file
+#
+VERSIONFILE =about.txt
+VERSIONPATTERN =[vV][eE][rR][sS][iI][oO][nN]:[[:blank:]]*v[[:blank:]]*[0-9]+\.[0-9]+\.[0-9]+
+VERSIONSTRING ="Version: v${VERSION}"
+
+FindAndSetVersion
+
+
+#
+# Adjust package/blocklypropclient-installer.iss file
+#
+VERSIONFILE =package/blocklypropclient-installer.iss
+VERSIONPATTERN =[mM][yY][aA][pP][pP][vV][eE][rR][sS][iI][oO][nN][[:blank:]]+\"[0-9]+\.[0-9]+\.[0-9]+\"
+VERSIONSTRING ="MyAppVersion \"${VERSION}\""
+
+FindAndSetVersion

--- a/set_version.sh
+++ b/set_version.sh
@@ -1,6 +1,7 @@
 #!/bin/sh --
 #
 # This script sets version number entries in various files in the BlocklyPropClient project.
+# Works in Ubuntu and OS X.
 #
 # Usage: $ ./set_version "1.2.3"
 
@@ -8,8 +9,8 @@
 #
 # Error if no version string declared
 #
+# if [ $1X == X ]     <-- this doesn't work in Ubuntu
 if [ -z "$1" ]
-#if [ $1X == X ]     <-- this doesn't work in Ubuntu
 then
     echo "ERROR: Must specify a version number.  Ex: \$ $0 \"1.2.3\""
     exit 1
@@ -32,8 +33,8 @@ VERSION=$1
 #       grep and sed, must use an expanded pattern for text where each letter is expressed in both upper/lower case.
 #       ex: Ver should be [vV][eE][rR]  
 #
+# function FindAndSetVersion {     <-- this doesn't work in Ubuntu
 FindAndSetVersion() {
-#function FindAndSetVersion {     <-- this doesn't work in Ubuntu
 if grep -q -E ${VERSIONPATTERN} ${VERSIONFILE} ; then
     if sed -i.bak -E "s/${VERSIONPATTERN}/${VERSIONSTRING}/" ${VERSIONFILE} ; then
         echo "Updated file \"${VERSIONFILE}\" to include: ${VERSIONSTRING}"

--- a/set_version.sh
+++ b/set_version.sh
@@ -46,7 +46,7 @@ fi
 
 
 #
-# Adjust BlocklyPropClient.py file
+# Adjust BlocklyPropClient.py file - [format: VERSION = "#.#.#"]
 #
 VERSIONFILE=BlocklyPropClient.py
 VERSIONPATTERN=[vV][eE][rR][sS][iI][oO][nN][[:blank:]]*=[[:blank:]]*\"[0-9]+\.[0-9]+\.[0-9]+\"
@@ -56,7 +56,7 @@ FindAndSetVersion
 
 
 #
-# Adjust about.txt file
+# Adjust about.txt file - [format: Version: v#.#.#]
 #
 VERSIONFILE=about.txt
 VERSIONPATTERN=[vV][eE][rR][sS][iI][oO][nN]:[[:blank:]]*v[[:blank:]]*[0-9]+\.[0-9]+\.[0-9]+
@@ -66,7 +66,7 @@ FindAndSetVersion
 
 
 #
-# Adjust package/blocklypropclient-installer.iss file
+# Adjust package/blocklypropclient-installer.iss file - [format: MyAppVersion "#.#.#"]
 #
 VERSIONFILE=package/blocklypropclient-installer.iss
 VERSIONPATTERN=[mM][yY][aA][pP][pP][vV][eE][rR][sS][iI][oO][nN][[:blank:]]+\"[0-9]+\.[0-9]+\.[0-9]+\"


### PR DESCRIPTION
- Moved task of setting the _application bundle version_ from the macos.spec file (ie: PyInstaller) to the mac_sign_and_package script.  This eliminates a formerly-manual step in the build process on the Mac.
- Created set_version script that adjusts project version in the appropriate files in the project.  This script is for use on Ubuntu or Mac OS X.
- Fixed official Parallax names in about.txt and Windows' .iss file
