### PR TITLE
Fixed mistake in mac_app... script that left backup Info.plist file in the application bundle.

### DIFF
--- a/package/mac_app_sign_and_package.sh
+++ b/package/mac_app_sign_and_package.sh
@@ -250,9 +250,10 @@ if [[ -e ${DISTRIBUTION}${APP_BUNDLE} ]]
 then
     if [[ -e ${DISTRIBUTION}${APP_BUNDLE}/Contents/Info.plist ]]
     then
-        if sed -i.bak s_\<string\>0.0.0\<\/string\>_\<string\>${VERSION}\<\/string\>_ ${DISTRIBUTION}${APP_BUNDLE}/Contents/Info.plist > ${DISTRIBUTION}${APP_BUNDLE}/Contents/Info2.plist
+        if sed -i.bak s_\<string\>0.0.0\<\/string\>_\<string\>${VERSION}\<\/string\>_ ${DISTRIBUTION}${APP_BUNDLE}/Contents/Info.plist
         then
             echo "Set bundle's Info.plist to version: \"${VERSION}\""
+            rm ${DISTRIBUTION}${APP_BUNDLE}/Contents/Info.plist.bak
         else
             echo "[Error] Could not set bundle's version in Info.plist."
             exit 1


### PR DESCRIPTION
The -i feature of sed requires an extension (on Mac) and created a backup file with that extension when in-place editing is performed.  I forgot about the backup file when I removed the code to delete temporary files; this caused an Info.plist.bak file to be left in the application bundle.