### PR TITLE
Linux fix

### DIFF
--- a/BlocklyPropClient.linux.spec
+++ b/BlocklyPropClient.linux.spec
@@ -1,28 +1,43 @@
 # -*- mode: python -*-
-a = Analysis(['BlocklyPropClient.py'],
 
+block_cipher = None
+
+
+a = Analysis(['BlocklyPropClient.py'],
+             binaries=None,
+             datas=None,
              hiddenimports=[],
-             hookspath=None,
-             runtime_hooks=None)
-pyz = PYZ(a.pure)
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher)
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
 exe = EXE(pyz,
           a.scripts,
           exclude_binaries=True,
           name='BlocklyPropClient',
           debug=False,
-          strip=None,
-          upx=false,
-          console=True,
-          icon='blocklyprop.ico' )
+          strip=False,
+          upx=False,
+          console=False , icon='BlocklyPropClient.ico')
+
+#Propeller Tools
 propeller_libs_and_tools = Tree('propeller-tools', prefix='propeller-tools', excludes=['*.pdf', 'windows', 'mac'])
+propeller_libs_and_tools += [('about.txt', 'about.txt', 'About file')]
+
+#Collection (edited to include Propeller Tools)
 coll = COLLECT(exe,
                a.binaries,
                a.zipfiles,
                a.datas,
                propeller_libs_and_tools,
-               strip=None,
+               strip=False,
                upx=False,
-               name='BlocklyPropClient.linux')
+               name='BlocklyPropClient')
 
 # Analysis
-#             pathex=['D:\\Development\\python\\BlocklyPropClient'],
+#             pathex=['/home/developer/Projects/BlocklyPropClient'],
+

--- a/BlocklyPropClient.py
+++ b/BlocklyPropClient.py
@@ -64,13 +64,15 @@ class BlocklyPropClient(tk.Tk):
         self.app_version = "0.0"
         self.connected = False
 
-        # Path to where application was launched
+        # Find the path from which application was launched
         # realpath expands to full path if __file__ or sys.argv[0] contains just a filename
 	self.appdir = os.path.dirname(os.path.realpath(__file__))
-        if self.appdir == "":
+        if self.appdir == "" or self.appdir == "/":
+	    # launch path is blank; try extracting from argv
             self.appdir = os.path.dirname(os.path.realpath(sys.argv[0]))
+
 	self.logger.info('Logging is enabled')
-	self.logger.info('Application launched from %s', self.appdir)
+	self.logger.info('BlocklyPropClient.py: Application launched from %s', self.appdir)
 
         # initialize config variables
         self.ip_address = tk.StringVar()

--- a/BlocklyPropClient.py
+++ b/BlocklyPropClient.py
@@ -34,7 +34,7 @@ PORT = 6009
 # NOTE:
 #
 # Please verify that the version number in the local about.txt and the
-# ./package/win0resources/blocklypropclient-installer.iss
+# ./package/win-resources/blocklypropclient-installer.iss matches this.
 # -----------------------------------------------------------------------
 VERSION = "0.5.4"
 
@@ -65,9 +65,11 @@ class BlocklyPropClient(tk.Tk):
         self.connected = False
 
         # Path to where application was launched
-        self.appdir = os.path.dirname(sys.argv[0])
-        self.logger.info('Logging is enabled')
-        self.logger.info('Application launched from %s', self.appdir)
+	# self.appdir = os.path.dirname(sys.argv[0])
+	# self.appdir = os.getcwd()   #works
+	self.appdir = os.path.dirname(os.path.realpath(__file__))
+	self.logger.info('Logging is enabled')
+	self.logger.info('Application launched from %s', self.appdir)
 
         # initialize config variables
         self.ip_address = tk.StringVar()

--- a/BlocklyPropClient.py
+++ b/BlocklyPropClient.py
@@ -65,9 +65,10 @@ class BlocklyPropClient(tk.Tk):
         self.connected = False
 
         # Path to where application was launched
-	# self.appdir = os.path.dirname(sys.argv[0])
-	# self.appdir = os.getcwd()   #works
+        # realpath expands to full path if __file__ or sys.argv[0] contains just a filename
 	self.appdir = os.path.dirname(os.path.realpath(__file__))
+        if self.appdir == "":
+            self.appdir = os.path.dirname(os.path.realpath(sys.argv[0]))
 	self.logger.info('Logging is enabled')
 	self.logger.info('Application launched from %s', self.appdir)
 

--- a/BlocklyServer.py
+++ b/BlocklyServer.py
@@ -27,7 +27,8 @@ class BlocklyServer(object):
 
         self.version = version
         self.queue = queue
-        self.appdir = os.path.dirname(sys.argv[0])
+	# self.appdir = os.path.dirname(sys.argv[0])
+	self.appdir = os.path.dirname(os.path.realpath(__file__))
         self.logger.debug("Application started from: %s", self.appdir)
 
         queue.put((10, 'INFO', 'Server started'))

--- a/BlocklyServer.py
+++ b/BlocklyServer.py
@@ -27,11 +27,15 @@ class BlocklyServer(object):
 
         self.version = version
         self.queue = queue
+
+        # Find the path from which application was launched
         # realpath expands to full path if __file__ or sys.argv[0] contains just a filename
 	self.appdir = os.path.dirname(os.path.realpath(__file__))
-        if self.appdir == "":
+        if self.appdir == "" or self.appdir == "/":
+	    # launch path is blank; try extracting from argv
             self.appdir = os.path.dirname(os.path.realpath(sys.argv[0]))
-        self.logger.debug("Application started from: %s", self.appdir)
+
+        self.logger.debug("BlocklyServer.py: Application started from: %s", self.appdir)
 
         queue.put((10, 'INFO', 'Server started'))
 

--- a/BlocklyServer.py
+++ b/BlocklyServer.py
@@ -27,8 +27,10 @@ class BlocklyServer(object):
 
         self.version = version
         self.queue = queue
-	# self.appdir = os.path.dirname(sys.argv[0])
+        # realpath expands to full path if __file__ or sys.argv[0] contains just a filename
 	self.appdir = os.path.dirname(os.path.realpath(__file__))
+        if self.appdir == "":
+            self.appdir = os.path.dirname(os.path.realpath(sys.argv[0]))
         self.logger.debug("Application started from: %s", self.appdir)
 
         queue.put((10, 'INFO', 'Server started'))

--- a/PropellerLoad.py
+++ b/PropellerLoad.py
@@ -19,13 +19,11 @@ class PropellerLoad:
         self.logger.info('Creating loader logger.')
 
         # Find the path to the application launch directory
-	# self.appdir = os.path.dirname(sys.argv[0])
-	# self.appdir = os.getcwd()   # works
+        # realpath expands to full path if __file__ or sys.argv[0] contains just a filename
 	self.appdir = os.path.dirname(os.path.realpath(__file__))
+        if self.appdir == "":
+            self.appdir = os.path.dirname(os.path.realpath(sys.argv[0]))
         self.logger.debug("Application running from: %s", self.appdir)
-
-#        if not self.appdir:
-#            self.appdir = os.getcwd()
 
         self.propeller_load_executables = {
             "Windows":  "/propeller-tools/windows/propeller-load.exe",
@@ -73,9 +71,11 @@ class PropellerLoad:
         self.loading = True
 
         # Patch until we figure out why the __init__ is not getting called
-        if not self.appdir or self.appdir == '':
-	    # self.appdir = os.path.dirname(sys.argv[0])
+	if not self.appdir or self.appdir == '':
+	    # realpath expands to full path if __file__ or sys.argv[0] contains just a filename
 	    self.appdir = os.path.dirname(os.path.realpath(__file__))
+            if self.appdir == "":
+                self.appdir = os.path.dirname(os.path.realpath(sys.argv[0]))
 
         executable = self.appdir + self.propeller_load_executables[platform.system()]
         self.logger.debug('Loader executable path is: %s)', executable)

--- a/PropellerLoad.py
+++ b/PropellerLoad.py
@@ -19,7 +19,9 @@ class PropellerLoad:
         self.logger.info('Creating loader logger.')
 
         # Find the path to the application launch directory
-        self.appdir = os.path.dirname(sys.argv[0])
+	# self.appdir = os.path.dirname(sys.argv[0])
+	# self.appdir = os.getcwd()   # works
+	self.appdir = os.path.dirname(os.path.realpath(__file__))
         self.logger.debug("Application running from: %s", self.appdir)
 
 #        if not self.appdir:
@@ -72,7 +74,8 @@ class PropellerLoad:
 
         # Patch until we figure out why the __init__ is not getting called
         if not self.appdir or self.appdir == '':
-            self.appdir = os.path.dirname(sys.argv[0])
+	    # self.appdir = os.path.dirname(sys.argv[0])
+	    self.appdir = os.path.dirname(os.path.realpath(__file__))
 
         executable = self.appdir + self.propeller_load_executables[platform.system()]
         self.logger.debug('Loader executable path is: %s)', executable)

--- a/PropellerLoad.py
+++ b/PropellerLoad.py
@@ -18,12 +18,13 @@ class PropellerLoad:
         self.logger = logging.getLogger('blockly.loader')
         self.logger.info('Creating loader logger.')
 
-        # Find the path to the application launch directory
+        # Find the path from which application was launched
         # realpath expands to full path if __file__ or sys.argv[0] contains just a filename
 	self.appdir = os.path.dirname(os.path.realpath(__file__))
-        if self.appdir == "":
+        if self.appdir == "" or self.appdir == "/":
+	    # launch path is blank; try extracting from argv
             self.appdir = os.path.dirname(os.path.realpath(sys.argv[0]))
-        self.logger.debug("Application running from: %s", self.appdir)
+        self.logger.debug("PropellerLoad.py: Application running from: %s", self.appdir)
 
         self.propeller_load_executables = {
             "Windows":  "/propeller-tools/windows/propeller-load.exe",
@@ -72,9 +73,10 @@ class PropellerLoad:
 
         # Patch until we figure out why the __init__ is not getting called
 	if not self.appdir or self.appdir == '':
-	    # realpath expands to full path if __file__ or sys.argv[0] contains just a filename
+            # realpath expands to full path if __file__ or sys.argv[0] contains just a filename
 	    self.appdir = os.path.dirname(os.path.realpath(__file__))
-            if self.appdir == "":
+            if self.appdir == "" or self.appdir == "/":
+	        # launch path is blank; try extracting from argv
                 self.appdir = os.path.dirname(os.path.realpath(sys.argv[0]))
 
         executable = self.appdir + self.propeller_load_executables[platform.system()]


### PR DESCRIPTION
- Fixed .linux.spec file to build application folder with about.txt file and other updated settings.
- Enhanced with a 1st and 2nd attempt at setting self.appdir variable with working folder path. 
  - Variances occur between platforms and launch methods; if 1st technique returns blank or root as launch path, the 2nd technique is used.  This covers all witnessed variances. 
  - This fix allows it to run from both source (enabling faster development cycles) as well as from the built application folder (nice user experience).