### PR TITLE
[Issue #57] Fixed server string format error.  No more annoying Value…

### DIFF
--- a/BlocklyServer.py
+++ b/BlocklyServer.py
@@ -69,9 +69,11 @@ class BlocklyServer(object):
             filtered_ports = []
             for port in ports:
                 self.logger.debug('Port %s discovered.', port)
+                # Filter out Bluetooth ports; they are risky to open and scan
                 if ' bt ' not in port.lower() and 'bluetooth' not in port.lower():
                     filtered_ports.append(port)
-                    self.logger.debug("Port %2 appended to list.", port)
+                else:
+                    self.logger.debug("Port %s filtered from the list.", port)
             return filtered_ports
         else:
             # No useable ports detected. Need to determine how the browser


### PR DESCRIPTION
…Error console messages!

This fixes the annoying console errors noted in Issue #57.  The error was due to a mistyped string formatter in a logger message and produced this output, multiple times, each time a serial port was requested/discovered:
```
2017-03-24 06:57:27,882 - blockly.server - DEBUG - Port /dev/ttyS0 discovered.
Traceback (most recent call last):
  File "/usr/lib/python2.7/logging/__init__.py", line 861, in emit
    msg = self.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 734, in format
    return fmt.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 465, in format
    record.message = record.getMessage()
  File "/usr/lib/python2.7/logging/__init__.py", line 329, in getMessage
    msg = msg % self.args
ValueError: unsupported format character ' ' (0x20) at index 7

```