### PR TITLE
Enabled coded download messages

### DIFF
--- a/BlocklyPropClient.py
+++ b/BlocklyPropClient.py
@@ -229,7 +229,7 @@ class BlocklyPropClient(tk.Tk):
             # read entered values and start server
             self.server_process = multiprocessing.Process(
                 target=BlocklyServer.main,
-                args=(int(self.port.get()), self.version, self.q))
+                args=(int(self.port.get()), self.version, self.app_version, self.q))
 
             self.server_process.start()
 

--- a/BlocklyPropClient.py
+++ b/BlocklyPropClient.py
@@ -36,7 +36,7 @@ PORT = 6009
 # Please verify that the version number in the local about.txt and the
 # ./package/win-resources/blocklypropclient-installer.iss matches this.
 # -----------------------------------------------------------------------
-VERSION = "0.7.0"
+VERSION = "0.7.5"
 
 
 # Enable logging for functions outside of the class definition

--- a/BlocklyServer.py
+++ b/BlocklyServer.py
@@ -21,11 +21,12 @@ module_logger = logging.getLogger('blockly.server')
 
 class BlocklyServer(object):
 
-    def __init__(self, version, queue):
+    def __init__(self, version, app_version, queue):
         self.logger = logging.getLogger('blockly.server')
         self.logger.info('Creating server logger.')
 
         self.version = version
+        self.app_version = app_version
         self.queue = queue
 
         # Find the path from which application was launched
@@ -47,9 +48,11 @@ class BlocklyServer(object):
     def index(self):
         cherrypy.response.headers['Access-Control-Allow-Origin'] = '*'
 
+        # version supports pre-0.99 web clients, version_str supports v0.99+ web clients
         serverinfo = {
             "server": "BlocklyPropHTTP",
-            "version": self.version
+            "version": self.version,
+            "version_str": self.app_version
         }
         self.queue.put((1, 'TRACE', 'Server poll received'))
         self.logger.debug('Server poll received')
@@ -125,7 +128,7 @@ class BlocklyServer(object):
         handler = cherrypy.request.ws_handler
 
 
-def main(port, version, queue):
+def main(port, version, app_version, queue):
     module_logger.info("Server starting")
     queue.put((10, 'INFO', 'Server starting'))
 
@@ -137,7 +140,7 @@ def main(port, version, queue):
 
     queue.put((10, 'INFO', 'Websocket configured'))
 
-    cherrypy.quickstart(BlocklyServer(version, queue), '/', config={'/serial.connect': {
+    cherrypy.quickstart(BlocklyServer(version, app_version, queue), '/', config={'/serial.connect': {
         'tools.websocket.on': True,
         'tools.websocket.handler_cls': SerialSocket
     }})

--- a/BlocklyServer.py
+++ b/BlocklyServer.py
@@ -85,7 +85,7 @@ class BlocklyServer(object):
     @cherrypy.expose(alias='load.action')
     @cherrypy.tools.json_out()
     @cherrypy.tools.allow(methods=['POST'])
-    def load(self, action, binary, extension, comport=None):
+    def load(self, option, action, binary, extension, comport=None):
         if action is None:
             self.logger.error('Load action is undefined.')
             return {
@@ -105,7 +105,7 @@ class BlocklyServer(object):
 
         self.logger.debug('Loading program to device.')
 
-        (success, out, err) = self.propellerLoad.download(action, binary_file, comport)
+        (success, out, err) = self.propellerLoad.download(option, action, binary_file, comport)
         self.queue.put((10, 'INFO', 'Application loaded (%s)' % action))
 
         self.logger.info('Application load complete.')

--- a/PropellerLoad.py
+++ b/PropellerLoad.py
@@ -64,6 +64,12 @@ class PropellerLoad:
             "EEPROM": {"compile-options": "-e"}
         }
 
+        self.loaderOption = {
+            "CODE":         {"loader-options": "-c"},
+            "VERBOSE":      {"loader-options": "-v"},
+            "CODE_VERBOSE": {"loader-options": "-c -v"}
+        }
+
         if not platform.system() in self.loaderExe:
             self.logger.error('The %s platform is not supported at this time.', platform.system())
             print(platform.system() + " is currently unsupported")
@@ -108,7 +114,7 @@ class PropellerLoad:
             self.discovering = False
 
 
-    def download(self, action, file_to_load, com_port):
+    def download(self, option, action, file_to_load, com_port):
         # Download application to Propeller
         # Set loading flag to prevent interruption
         self.loading = True
@@ -127,11 +133,17 @@ class PropellerLoad:
 #                    # launch path is blank; try extracting from argv
 #                    self.appdir = os.path.dirname(os.path.realpath(sys.argv[0]))
 
-            # Set command to download to RAM or EEPROM and to run afterward download
+            # Set command options to download to RAM or EEPROM and to run afterward download
             command = []
+
+            if self.loaderOption[option]["loader-options"] != "":
+                # if loader-option not empty, add it to the list
+                command.extend([self.loaderOption[option]["loader-options"]])
+
             if self.loaderAction[action]["compile-options"] != "":
                 # if RAM/EEPROM compile-option not empty, add it to the list
                 command.extend([self.loaderAction[action]["compile-options"]])
+
             command.extend(["-r"])
 
             # Specify requested port

--- a/PropellerLoad.py
+++ b/PropellerLoad.py
@@ -133,7 +133,7 @@ class PropellerLoad:
 #                    # launch path is blank; try extracting from argv
 #                    self.appdir = os.path.dirname(os.path.realpath(sys.argv[0]))
 
-            # Set command options to download to RAM or EEPROM and to run afterward download
+            # Set command options to download to RAM or EEPROM and to run after download
             command = []
 
             if self.loaderOption[option]["loader-options"] != "":

--- a/about.txt
+++ b/about.txt
@@ -1,4 +1,4 @@
-Version: v0.7.0
+Version: v0.7.5
 
 Contributors:
 - Michel Lampo

--- a/package/blocklypropclient-installer.iss
+++ b/package/blocklypropclient-installer.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "BlocklyPropClient"
-#define MyAppVersion "0.7.0"
+#define MyAppVersion "0.7.5"
 #define MyAppPublisher "Parallax Inc."
 #define MyAppURL "http://blockly.parallax.com/"
 #define MyAppExeName "BlocklyPropClient.exe"


### PR DESCRIPTION
- Enhanced to accept 'loader-options' of CODE, VERBOSE, or CODE_VERBOSE to invoke -c and/or -v option for PropLoader.  This causes messages to be coded.
- Enhanced to deliver version as a string to communicate version as major.minor.patch to web client 0.99+.
- Bumped version to v0.7.5